### PR TITLE
Make DDK Opencl dependencies conditional

### DIFF
--- a/graphics.mk
+++ b/graphics.mk
@@ -33,8 +33,12 @@ endif
 ifeq ($(DDK_UM_PREBUILDS),)
 # Build DDK-UM
 DDK_UM_DEP=img_ddk_um
+
+ifeq ($(DDK_BUILD_OPENCL),true)
 $(call inherit-product-if-exists, vendor/imagination/clang/device-vendor.mk)
 $(call inherit-product-if-exists, vendor/imagination/llvm/device-vendor.mk)
+endif
+
 PRODUCT_PACKAGES += $(DDK_UM_DEP)
 else
 # Use DDK-UM from prebuilds


### PR DESCRIPTION
There is no need to build llvm and clang if
opencl is not supported.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>