### PR TITLE
Added external touchscreen support

### DIFF
--- a/Vendor_5853_Product_fffd.idc
+++ b/Vendor_5853_Product_fffd.idc
@@ -1,0 +1,20 @@
+# Copyright 2019 EPAM Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+device.internal = 1
+touch.deviceType = touchScreen
+touch.primarydevice = /dev/input/event1
+touch.externaldevice = /dev/input/event3
+

--- a/device.mk
+++ b/device.mk
@@ -111,6 +111,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     packages/services/Car/car_product/bootanimations/bootanimation-832.zip:system/media/bootanimation.zip
 
+# Input configuration
+PRODUCT_COPY_FILES += \
+    device/xen/xenvm/Vendor_5853_Product_fffd.idc:$(TARGET_COPY_OUT_VENDOR)/usr/idc/Vendor_5853_Product_fffd.idc \
+
 # Native apps for audio
 PRODUCT_PACKAGES += \
     tinyplay \


### PR DESCRIPTION
Vendor_5853_Product_fffd.idc will declare mapping
of primary(display 0) and external(display 1) devices.devices

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>