### PR TITLE
audio: Enable dynamic routing required for audio buses

### DIFF
--- a/overlay/packages/services/Car/service/res/values/config.xml
+++ b/overlay/packages/services/Car/service/res/values/config.xml
@@ -1,0 +1,6 @@
+<resources>
+    <!--  Configuration to enable usage of dynamic audio routing. If this is set to false,
+          dynamic audio routing is disabled and audio works in legacy mode. It may be useful
+          during initial development where audio hal does not support bus based addressing yet. -->
+    <bool name="audioUseDynamicRouting">true</bool>
+</resources>


### PR DESCRIPTION
This fix restores part of
ad61ee4 Add support for automotive audio buses
that was removed during transition to A10 by
0de9920 Update overlay for Android 10
due to significant changes in structure of overlay.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>