### PR TITLE
xenvm: Reorganize partition mount

### DIFF
--- a/fstab.xenvm
+++ b/fstab.xenvm
@@ -1,5 +1,5 @@
-/dev/block/xvda1           /               ext4    ro,barrier=1                  	 wait
-/dev/block/xvda3           /misc           emmc    defaults                              defaults
-/dev/block/xvda4           /vbmeta         emmc    defaults                              defaults
-/dev/block/xvda5           /metadata       ext4    noatime,nosuid,                       wait,check
-/dev/block/xvda6           /data           ext4    noatime,nosuid,barrier=1              wait,check,latemount
+/dev/block/by-name/system             /               ext4    ro,barrier=1                          wait
+/dev/block/by-name/misc               /misc           emmc    defaults                              defaults
+/dev/block/by-name/vbmeta             /vbmeta         emmc    defaults                              defaults
+/dev/block/by-name/metadata           /metadata       ext4    noatime,nosuid,                       wait,check
+/dev/block/by-name/userdata           /data           ext4    noatime,nosuid,barrier=1              wait,check,latemount


### PR DESCRIPTION
Mount partitions by name, instead of the direct device name.
To enable /dev/block/by-name symlinks, user must add to
kernel cmdline a new parameter androidboot.boot_devices.
Which is a part of the device path in real by-name path.
I.e. for /dev/block/vbd/51712/by-name it will be 51712.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>