### PR TITLE
configstore: Set correct dependency version

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -155,7 +155,7 @@ PRODUCT_PACKAGES += \
 
 # Config store HAL
 PRODUCT_PACKAGES += \
-    android.hardware.configstore@1.0-impl
+    android.hardware.configstore@1.1-service
 
 # Audio
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
In manifest.xml, configstore version is set to 1.1, which
is correct. In device.mk version set to 1.0 by mistake.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>