### PR TITLE
audio: remove 12000 from list of supported sample rates

### DIFF
--- a/audio_policy_configuration.xml
+++ b/audio_policy_configuration.xml
@@ -81,7 +81,7 @@
             </mixPort>
             <mixPort name="primary input" role="sink">
               <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                       samplingRates="8000,11025,12000,16000,22050,32000,44100,48000"
+                       samplingRates="8000,11025,16000,22050,32000,44100,48000"
                        channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
             </mixPort>
           </mixPorts>
@@ -154,17 +154,17 @@
 
             <devicePort tagName="Built-In Mic" type="AUDIO_DEVICE_IN_BUILTIN_MIC" role="source">
               <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                       samplingRates="8000,11025,12000,16000,22050,32000,44100,48000"
+                       samplingRates="8000,11025,16000,22050,32000,44100,48000"
                        channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
             </devicePort>
             <devicePort tagName="Line In" type="AUDIO_DEVICE_IN_LINE" role="source">
               <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                       samplingRates="8000,11025,12000,16000,22050,32000,44100,48000"
+                       samplingRates="8000,11025,16000,22050,32000,44100,48000"
                        channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
             </devicePort>
             <devicePort tagName="bus0_in" type="AUDIO_DEVICE_IN_BUS" role="source" address="bus0_in">
               <profile name="" format="AUDIO_FORMAT_PCM_16_BIT"
-                       samplingRates="8000,11025,12000,16000,22050,32000,44100,48000"
+                       samplingRates="8000,11025,16000,22050,32000,44100,48000"
                        channelMasks="AUDIO_CHANNEL_IN_MONO,AUDIO_CHANNEL_IN_STEREO"/>
               <gains>
                   <gain name="" mode="AUDIO_GAIN_MODE_JOINT" minValueMB="-3200" maxValueMB="600" defaultValueMB="0" stepValueMB="100"/>


### PR DESCRIPTION
This frequency is not mentioned in CDD 9, 10, 11.
Seems like included by mistake.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>