### PR TITLE
xenvm: Add vndservicemanager dependancy

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -25,6 +25,8 @@ PRODUCT_USE_VNDK := true
 PRODUCT_FULL_TREBLE := true
 PRODUCT_ENFORCE_VINTF_MANIFEST := true
 
+PRODUCT_PACKAGES += vndservicemanager
+
 # Boot control HAL (libavb)
 PRODUCT_PACKAGES +=  \
     android.hardware.boot@1.1-impl \


### PR DESCRIPTION
Devices launching with Android 11 or later which need to
use vdbinder(evs aplication) must explicitly opt into
using vndservicemanager by adding it to  PRODUCT_PACKAGES.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>