### PR TITLE
audio: Set default tracks for volume control

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -67,6 +67,18 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.carrier=unknown \
     persist.vehicle.use-vis-hal=false \
 
+# Define audio tracks that we want to use as default.
+# Do not change method of assignment because new values have to be prepended
+# and not appended (do not use +=). Explanation from google's groups:
+# "For PRODUCT_PROPERTY_OVERRIDES ... the first instance takes precedence."
+# For same reason this override has to be used after include of car.mk
+# in order to use our values.
+PRODUCT_PROPERTY_OVERRIDES := \
+     ro.config.ringtone=Atria.ogg \
+     ro.config.notification_sound=Tethys.ogg \
+     ro.config.alarm_alert=Oxygen.ogg \
+     $(PRODUCT_PROPERTY_OVERRIDES)
+
 PRODUCT_PROPERTY_OVERRIDES += ro.sf.lcd_density=160
 
 PRODUCT_TAGS += dalvik.gc.type-precise


### PR DESCRIPTION
Define audio tracks that we want to use as default
for sound volume controls.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>