### PR TITLE
Chnage VISS service port

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -19,6 +19,8 @@ $(call inherit-product, build/target/product/core_64_bit.mk)
 $(call inherit-product, frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk)
 $(call inherit-product, packages/services/Car/car_product/build/car.mk)
 
+# VISS
+PRODUCT_PROPERTY_OVERRIDES += persist.vis.uri="wss://wwwivi:443"
 
 # Boot control HAL (libavb)
 PRODUCT_PACKAGES +=  \


### PR DESCRIPTION
According to documentation [1],
default VISS port is 443.

[1] https://www.w3.org/TR/vehicle-information-service/#initialisation-of-the-websocket

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>