### PR TITLE
Change VISS service port

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -19,6 +19,9 @@ $(call inherit-product, build/target/product/core_64_bit.mk)
 $(call inherit-product, frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk)
 $(call inherit-product, packages/services/Car/car_product/build/car.mk)
 
+# VISS
+PRODUCT_PROPERTY_OVERRIDES += persist.vis.uri="wss://wwwivi:443"
+
 # Add preffered configurations
 PRODUCT_AAPT_CONFIG := normal large xlarge hdpi xhdpi
 PRODUCT_AAPT_PREF_CONFIG := hdpi


### PR DESCRIPTION
According to documentation [1],
default VISS port is 443.

[1] https://www.w3.org/TR/vehicle-information-service/#initialisation-of-the-websocket

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>