### PR TITLE
drm_hwcomposer: Chose correct backend for xenvm

### DIFF
--- a/build/device.mk
+++ b/build/device.mk
@@ -225,6 +225,8 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     hwcomposer.$(TARGET_PRODUCT) \
 
+PRODUCT_PROPERTY_OVERRIDES += vendor.hwc.backend_override="oneplane-du"
+
 # Modetest from libdrm
 PRODUCT_PACKAGES += \
     modetest \


### PR DESCRIPTION
Use oneplane-du backend for xenvm instead of
the default one.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>