### PR TITLE
Set triple buffering for SurfaceFlinger composition

### DIFF
--- a/build/device.mk
+++ b/build/device.mk
@@ -202,6 +202,9 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.automotive.audiocontrol@1.0-service \
 
+# SurfaceFlinger compostion buffers count
+PRODUCT_PROPERTY_OVERRIDES += ro.surface_flinger.max_frame_buffer_acquired_buffers=3
+
 # Composer 2.3
 PRODUCT_PACKAGES += \
     android.hardware.graphics.composer@2.3-hal \


### PR DESCRIPTION
In virtualized systems, guest VMs appears to be frame
providers. Real hardware appears in some separate
domains and guest VMs could not control the frame
display momentum. I.e. display latency may be near
or even equal to the frame period. This may cause a
starving state for guest VM composition renderer.
Triple buffering is the solution for mentioned situations.

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>