### PR TITLE
Change vis parameter name to comply with Android 12

### DIFF
--- a/build/device.mk
+++ b/build/device.mk
@@ -31,7 +31,7 @@ PRODUCT_ENFORCE_VINTF_MANIFEST := true
 
 PRODUCT_PACKAGES += vndservicemanager
 # VISS
-PRODUCT_PROPERTY_OVERRIDES += persist.vis.uri="wss://wwwivi:443"
+PRODUCT_PROPERTY_OVERRIDES += persist.vendor.vis.uri="wss://wwwivi:443"
 
 # Boot control HAL (libavb)
 PRODUCT_PACKAGES +=  \


### PR DESCRIPTION
Change 'persist.vis.uri' to 'persist.vendor.vis.uri' in order to fit to the Android 12 properties naming convention