### PR TITLE
xenvm: fix gnss build error

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -130,15 +130,6 @@
         </interface>
     </hal>
     <hal format="hidl">
-        <name>android.hardware.gnss</name>
-        <transport>hwbinder</transport>
-        <version>1.1</version>
-        <interface>
-            <name>IGnss</name>
-            <instance>default</instance>
-        </interface>
-    </hal>
-    <hal format="hidl">
         <name>android.hardware.drm</name>
         <transport>hwbinder</transport>
         <version>1.0</version>


### PR DESCRIPTION
Remove gnss record from global manifest.xml,
since manifest fragment related to the gnss
was added to gnss project repository.