### PR TITLE
audio: enable USB Audio HAL

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -54,6 +54,7 @@ TARGET_ENABLE_MEDIADRM_64 := false
 
 USE_CAMERA_STUB := true
 USE_OPENGL_RENDERER := true
+USE_USB_AUDIO := true
 
 # Android images
 TARGET_USERIMAGES_USE_EXT4 := true

--- a/audio_policy_configuration.xml
+++ b/audio_policy_configuration.xml
@@ -185,6 +185,11 @@
           </routes>
         </module>
 
+        <module name="usb" halVersion="3.0">
+            <device type="AUDIO_DEVICE_OUT_USB_ACCESSORY"/>
+            <device type="AUDIO_DEVICE_OUT_USB_DEVICE"/>
+            <device type="AUDIO_DEVICE_IN_USB_DEVICE"/>
+        </module>
     </modules>
 
     <xi:include href="audio_policy_volumes.xml"/>

--- a/build/device.mk
+++ b/build/device.mk
@@ -150,6 +150,7 @@ PRODUCT_COPY_FILES +=\
     device/xen/xenvm/init.xenvm.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.xenvm.rc \
     device/xen/xenvm/init.xenvm.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.xenvm.usb.rc \
     device/xen/xenvm/ueventd.xenvm.rc:$(TARGET_COPY_OUT_VENDOR)/etc/ueventd.rc \
+    device/xen/xenvm/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml \
     packages/services/Car/car_product/init/init.car.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.car.rc \
     packages/services/Car/car_product/init/init.bootstat.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.bootstat.rc
 
@@ -327,6 +328,10 @@ PRODUCT_PACKAGES += \
     android.hardware.thermal@1.0.vendor \
     libdrm \
 
+PRODUCT_PACKAGES += \
+    audio.usb.default \
+    audio.usbv2.default
+
 # Sw GK KM
 # Keymaster HAL
 # All security related settings are moved into dedicated security.mk
@@ -408,6 +413,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.hardware.audio.primary=caremu-ext \
     ro.vendor.caremu.audiohal.out_period_ms=16 \
     ro.vendor.caremu.audiohal.in_period_ms=16
+
+# Enable audio source for USB Audio
+PRODUCT_PROPERTY_OVERRIDES += \
+    persist.sys.usb.config=audio_source,adb
 
 # Car Emulator Audio HAL
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
    The V4H Evaluation Module does not have Audio CODEC.
    Audio is required in case of Infotainment OS like Android.
    So, enabled USB Audio HALs for adding external USB based CODEC
    Adaptors.

    Depends on below kernel configurations to be enbaled on
    the defconfig:

    CONFIG_SND_USB=y
    CONFIG_SND_USB_AUDIO=y
