### PR TITLE
audio: Enable Remote Submix audio HAL

### DIFF
--- a/audio_policy_configuration.xml
+++ b/audio_policy_configuration.xml
@@ -190,6 +190,9 @@
             <device type="AUDIO_DEVICE_OUT_USB_DEVICE"/>
             <device type="AUDIO_DEVICE_IN_USB_DEVICE"/>
         </module>
+
+        <!-- Remote Submix Audio HAL -->
+        <xi:include href="r_submix_audio_policy_configuration.xml"/>
     </modules>
 
     <xi:include href="audio_policy_volumes.xml"/>

--- a/build/device.mk
+++ b/build/device.mk
@@ -150,7 +150,6 @@ PRODUCT_COPY_FILES +=\
     device/xen/xenvm/init.xenvm.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.xenvm.rc \
     device/xen/xenvm/init.xenvm.usb.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/hw/init.xenvm.usb.rc \
     device/xen/xenvm/ueventd.xenvm.rc:$(TARGET_COPY_OUT_VENDOR)/etc/ueventd.rc \
-    device/xen/xenvm/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml \
     packages/services/Car/car_product/init/init.car.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.car.rc \
     packages/services/Car/car_product/init/init.bootstat.rc:$(TARGET_COPY_OUT_VENDOR)/etc/init/init.bootstat.rc
 
@@ -188,6 +187,15 @@ PRODUCT_COPY_FILES += \
     frameworks/av/media/libstagefright/data/media_codecs_google_video.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_video.xml \
     frameworks/av/media/libstagefright/data/media_codecs_google_audio.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_codecs_google_audio.xml \
     device/xen/xenvm/media_profiles.xml:$(TARGET_COPY_OUT_VENDOR)/etc/media_profiles_V1_0.xml
+
+# audio config xml file
+PRODUCT_COPY_FILES += \
+    device/xen/xenvm/audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_configuration.xml \
+    device/xen/xenvm/car_audio_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/car_audio_configuration.xml \
+    device/xen/xenvm/audio_effects.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_effects.xml \
+    frameworks/av/services/audiopolicy/config/r_submix_audio_policy_configuration.xml:$(TARGET_COPY_OUT_VENDOR)/etc/r_submix_audio_policy_configuration.xml \
+    frameworks/av/services/audiopolicy/config/default_volume_tables.xml:$(TARGET_COPY_OUT_VENDOR)/etc/default_volume_tables.xml \
+    frameworks/av/services/audiopolicy/config/audio_policy_volumes.xml:$(TARGET_COPY_OUT_VENDOR)/etc/audio_policy_volumes.xml \
 
 PRODUCT_PACKAGES += \
     android.hardware.drm@1.0-service \
@@ -444,3 +452,4 @@ $(call inherit-product-if-exists, frameworks/base/data/fonts/fonts.mk)
 $(call inherit-product, device/xen/xenvm/build/kernel_modules.mk)
 $(call inherit-product-if-exists, vendor/epam/aosp-hmi/epam-automotive-launcher.mk)
 $(call inherit-product-if-exists, vendor/epam/EpamSystemUI/epam-systemui.mk)
+$(call inherit-product-if-exists, vendor/epam/EpamMusic/epam-audio.mk)


### PR DESCRIPTION
The scrcpy uses Remote Submix audio HAL to record system audio output. 
For verification scrcpy v3.2 was used and OMX service(debug.stagefright.c2inputsurface=-1) was used to create input surface. Enable EpamMusic application.

Signed-off-by: Dmytro Klimenko <dmytro_klimenko@epam.com>
Reviewed-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>