### PR TITLE
xenvm: USB Bluetooth device permanent path.

### DIFF
--- a/bluetooth/usb_bt_init.sh
+++ b/bluetooth/usb_bt_init.sh
@@ -1,0 +1,43 @@
+#!/system/bin/sh
+
+# Find Tp-Link UB500 Realtek 8761B Bluetooth device
+VENDOR_ID="2357"
+PRODUCT_ID="0604"
+
+# Search for the device path
+DEVICE_PATH=""
+for dev in /sys/bus/usb/devices/*; do
+    if [ -f "$dev/idVendor" ] && [ -f "$dev/idProduct" ]; then
+        if grep -q "$VENDOR_ID" "$dev/idVendor" && grep -q "$PRODUCT_ID" "$dev/idProduct"; then
+            DEVICE_PATH="$dev"
+            break
+        fi
+    fi
+done
+
+if [ -n "$DEVICE_PATH" ]; then
+    # Extract the bus and device numbers
+    # Get busnum and devnum from sysfs
+    BUS_NUM=$(cat "$DEVICE_PATH/busnum")
+    DEV_NUM=$(cat "$DEVICE_PATH/devnum")
+
+    # Format as 3-digit numbers (as in /dev/bus/usb/XXX/YYY)
+    BUS_NUM=$(printf "%03d" "$BUS_NUM")
+    DEV_NUM=$(printf "%03d" "$DEV_NUM")
+
+    DEVICE_NODE="/dev/bus/usb/$BUS_NUM/$DEV_NUM"
+    log -t usb_bt_init "Device node is $DEVICE_NODE"
+
+    # Create the symlink
+    ln -sf $DEVICE_NODE /dev/usb-bluetooth
+
+    # Set permissions and ownership
+    chmod 0660 /dev/usb-bluetooth
+    chown bluetooth:bluetooth /dev/usb-bluetooth
+
+    # Log the event
+    log -t usb_bt_init "USB Bluetooth device symlink created"
+else
+    # Log the error
+    log -t usb_bt_init "USB Bluetooth device not found"
+fi

--- a/build/device.mk
+++ b/build/device.mk
@@ -272,6 +272,7 @@ PRODUCT_PACKAGES += \
 PRODUCT_COPY_FILES += \
     device/xen/xenvm/bluetooth/firmware/rtl8761b_fw.bin:$(TARGET_COPY_OUT_VENDOR)/firmware/rtl_bt/rtl8761b_fw.bin \
     device/xen/xenvm/bluetooth/firmware/rtl8761b_config.bin:$(TARGET_COPY_OUT_VENDOR)/firmware/rtl_bt/rtl8761b_config.bin \
+    device/xen/xenvm/bluetooth/usb_bt_init.sh:$(TARGET_COPY_OUT_VENDOR)/bin/usb_bt_init.sh \
 
 # Set default log size on userdebug/eng builds to 2M
 ifneq (,$(filter userdebug eng, $(TARGET_BUILD_VARIANT)))

--- a/init.xenvm.rc
+++ b/init.xenvm.rc
@@ -61,6 +61,13 @@ on late-init
     chmod 666 /dev/video0
     start tee_supplicant
 
+service usb_bt_init /vendor/bin/usb_bt_init.sh
+    class main
+    user root
+    group root
+    oneshot
+    seclabel u:r:vendor_shell:s0
+
 service pvrsrvctl /vendor/bin/pvrsrvctl --start
     class hal
     user root
@@ -90,3 +97,6 @@ on property:sys.boot_completed=1 && property:persist.vendor.xenvm-postinstall-do
     exec u:object_r:system_file:s0 root root -- /system/bin/wm density 160 -d 2
     exec u:object_r:system_file:s0 root root -- /system/bin/cmd -w settings put global show_notification_channel_warnings 0
     setprop persist.vendor.xenvm-postinstall-done 1
+
+on property:sys.boot_completed=1
+    start usb_bt_init

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -91,3 +91,5 @@
 /vendor/lib(64)?/hw/audio.primary.xenvm.so                                   u:object_r:same_process_hal_file:s0
 /vendor/lib(64)?/hw/audio.r_submix.xenvm.so                                  u:object_r:same_process_hal_file:s0
 
+# USB Bluetooth
+/vendor/bin/usb_bt_init\.sh                                                  u:object_r:vendor_shell_exec:s0

--- a/ueventd.xenvm.rc
+++ b/ueventd.xenvm.rc
@@ -17,4 +17,4 @@
 /dev/v4l-subdev0        0666    media           media
 /dev/v4l-subdev2        0666    media           media
 /dev/v4l-subdev3        0666    media           media
-/dev/bus/usb/001/005    0666    bluetooth       bluetooth
+/dev/usb-bluetooth      0660    bluetooth       bluetooth


### PR DESCRIPTION
Add a script to configure permanent path for the USB Bluetooth device, 
even if the actual USB Bluetooth device path changes.